### PR TITLE
feat: scaffold AWS Lambda crates for route and scout endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- 2025-11-18 - GitHub Copilot - [workspace] - Scaffolded three AWS Lambda crates (`evefrontier-lambda-route`, `evefrontier-lambda-scout-gates`, `evefrontier-lambda-scout-range`) with minimal handler stubs. Added `lambda_runtime` and `tokio` to workspace dependencies. Full handler implementation deferred to separate tasks.
 - 2025-11-16 - GitHub Copilot - [refactor] - Added conservative HTTP retries with exponential backoff in downloader (`github.rs`) for release metadata and asset downloads; improves robustness without API changes. Aligned with OWASP guidance (timeouts, transient failure handling).
 - 2025-11-15 - GitHub Copilot - [fix] - Corrected b parameter from 1.125 to 1.25 (transcription error) - now matches expected values exactly
 - 2025-11-15 - GitHub Copilot - [docs] - Documented exact EVE Frontier temperature formula with test cases in ADR 0012 and temperature module

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +495,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "evefrontier-lambda-route"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "evefrontier-lib",
+ "lambda_runtime",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "evefrontier-lambda-scout-gates"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "evefrontier-lib",
+ "lambda_runtime",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "evefrontier-lambda-scout-range"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "evefrontier-lib",
+ "lambda_runtime",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "evefrontier-lib"
 version = "0.1.0"
 dependencies = [
@@ -571,6 +635,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,10 +666,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -610,8 +711,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -751,6 +854,16 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]
@@ -1002,6 +1115,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambda_runtime"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed49669d6430292aead991e19bf13153135a884f916e68f32997c951af637ebe"
+dependencies = [
+ "async-stream",
+ "base64",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-serde",
+ "hyper",
+ "hyper-util",
+ "lambda_runtime_api_client",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tracing",
+]
+
+[[package]]
+name = "lambda_runtime_api_client"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90a10f094475a34a04da2be11686c4dcfe214d93413162db9ffdff3d3af293a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "tokio",
+ "tower 0.4.13",
+ "tower-service",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,6 +1324,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1455,7 +1637,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -1619,6 +1801,17 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
  "serde",
  "serde_core",
 ]
@@ -1832,7 +2025,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1846,12 +2051,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1882,7 +2113,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -1905,6 +2136,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1943,6 +2175,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,12 +2194,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 members = [
     "crates/evefrontier-lib",
     "crates/evefrontier-cli",
+    "crates/evefrontier-lambda-route",
+    "crates/evefrontier-lambda-scout-gates",
+    "crates/evefrontier-lambda-scout-range",
 ]
 resolver = "2"
 
@@ -62,10 +65,16 @@ rusqlite = { version = "0.37.0", features = ["bundled"] }
 clap = { version = "4.5.51", features = ["derive"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
-reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12.24", default-features = false, features = [
+    "blocking",
+    "json",
+    "rustls-tls",
+] }
 tempfile = "3.23.0"
 zip = { version = "6.0.0", default-features = false, features = ["deflate"] }
 assert_cmd = "2.1.1"
 predicates = "3.1.3"
 once_cell = "1.21.3"
 rusty-hook = "0.11.2"
+lambda_runtime = "0.13"
+tokio = { version = "1.42", features = ["macros"] }

--- a/crates/evefrontier-lambda-route/Cargo.toml
+++ b/crates/evefrontier-lambda-route/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "evefrontier-lambda-route"
+version = "0.1.0"
+edition = "2021"
+authors = ["EveFrontier Contributors"]
+description = "AWS Lambda function for route computation using EveFrontier dataset."
+license = "Apache-2.0"
+
+[dependencies]
+evefrontier-lib = { path = "../evefrontier-lib" }
+lambda_runtime.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tokio.workspace = true

--- a/crates/evefrontier-lambda-route/src/main.rs
+++ b/crates/evefrontier-lambda-route/src/main.rs
@@ -1,0 +1,42 @@
+use lambda_runtime::{service_fn, Error, LambdaEvent};
+use serde::{Deserialize, Serialize};
+
+/// Request structure for route computation.
+/// TODO: Replace with actual route request model (see docs/TODO.md lines 110-123).
+#[derive(Deserialize)]
+struct RouteRequest {
+    from: String,
+    to: String,
+}
+
+/// Response structure for route computation.
+/// TODO: Replace with actual route response model (see docs/TODO.md lines 110-123).
+#[derive(Serialize)]
+struct RouteResponse {
+    message: String,
+}
+
+/// Lambda function handler.
+/// TODO: Implement actual routing logic using evefrontier_lib::plan_route (see docs/TODO.md lines 110-123).
+async fn function_handler(event: LambdaEvent<RouteRequest>) -> Result<RouteResponse, Error> {
+    let (request, _context) = event.into_parts();
+
+    // Placeholder response
+    Ok(RouteResponse {
+        message: format!(
+            "Route computation from '{}' to '{}' not yet implemented",
+            request.from, request.to
+        ),
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    lambda_runtime::run(service_fn(function_handler)).await
+}

--- a/crates/evefrontier-lambda-scout-gates/Cargo.toml
+++ b/crates/evefrontier-lambda-scout-gates/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "evefrontier-lambda-scout-gates"
+version = "0.1.0"
+edition = "2021"
+authors = ["EveFrontier Contributors"]
+description = "AWS Lambda function for gate scouting using EveFrontier dataset."
+license = "Apache-2.0"
+
+[dependencies]
+evefrontier-lib = { path = "../evefrontier-lib" }
+lambda_runtime.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tokio.workspace = true

--- a/crates/evefrontier-lambda-scout-gates/src/main.rs
+++ b/crates/evefrontier-lambda-scout-gates/src/main.rs
@@ -1,0 +1,43 @@
+use lambda_runtime::{service_fn, Error, LambdaEvent};
+use serde::{Deserialize, Serialize};
+
+/// Request structure for gate scouting.
+/// TODO: Replace with actual scout-gates request model (see docs/TODO.md lines 110-123).
+#[derive(Deserialize)]
+struct ScoutGatesRequest {
+    system: String,
+}
+
+/// Response structure for gate scouting.
+/// TODO: Replace with actual scout-gates response model (see docs/TODO.md lines 110-123).
+#[derive(Serialize)]
+struct ScoutGatesResponse {
+    message: String,
+}
+
+/// Lambda function handler.
+/// TODO: Implement actual gate scouting logic using evefrontier_lib (see docs/TODO.md lines 110-123).
+async fn function_handler(
+    event: LambdaEvent<ScoutGatesRequest>,
+) -> Result<ScoutGatesResponse, Error> {
+    let (request, _context) = event.into_parts();
+
+    // Placeholder response
+    Ok(ScoutGatesResponse {
+        message: format!(
+            "Gate scouting for system '{}' not yet implemented",
+            request.system
+        ),
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    lambda_runtime::run(service_fn(function_handler)).await
+}

--- a/crates/evefrontier-lambda-scout-range/Cargo.toml
+++ b/crates/evefrontier-lambda-scout-range/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "evefrontier-lambda-scout-range"
+version = "0.1.0"
+edition = "2021"
+authors = ["EveFrontier Contributors"]
+description = "AWS Lambda function for range scouting using EveFrontier dataset."
+license = "Apache-2.0"
+
+[dependencies]
+evefrontier-lib = { path = "../evefrontier-lib" }
+lambda_runtime.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tokio.workspace = true

--- a/crates/evefrontier-lambda-scout-range/src/main.rs
+++ b/crates/evefrontier-lambda-scout-range/src/main.rs
@@ -1,0 +1,44 @@
+use lambda_runtime::{service_fn, Error, LambdaEvent};
+use serde::{Deserialize, Serialize};
+
+/// Request structure for range scouting.
+/// TODO: Replace with actual scout-range request model (see docs/TODO.md lines 110-123).
+#[derive(Deserialize)]
+struct ScoutRangeRequest {
+    system: String,
+    range: f64,
+}
+
+/// Response structure for range scouting.
+/// TODO: Replace with actual scout-range response model (see docs/TODO.md lines 110-123).
+#[derive(Serialize)]
+struct ScoutRangeResponse {
+    message: String,
+}
+
+/// Lambda function handler.
+/// TODO: Implement actual range scouting logic using evefrontier_lib (see docs/TODO.md lines 110-123).
+async fn function_handler(
+    event: LambdaEvent<ScoutRangeRequest>,
+) -> Result<ScoutRangeResponse, Error> {
+    let (request, _context) = event.into_parts();
+
+    // Placeholder response
+    Ok(ScoutRangeResponse {
+        message: format!(
+            "Range scouting for system '{}' within {} ly not yet implemented",
+            request.system, request.range
+        ),
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    lambda_runtime::run(service_fn(function_handler)).await
+}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -23,7 +23,7 @@ Tasks are grouped by domain; checkboxes track completion status.
 - [x] Add CI validation step that runs example commands from README/USAGE docs to ensure they continue working
 ## Workspace & Tooling
 
-- [ ] Establish the Cargo workspace layout with `crates/evefrontier-lib`, `crates/evefrontier-cli`,
+- [x] Establish the Cargo workspace layout with `crates/evefrontier-lib`, `crates/evefrontier-cli`,
       and Lambda crates (for example `crates/evefrontier-lambda-route`, `crates/evefrontier-lambda-scout-gates`,
       `crates/evefrontier-lambda-scout-range`). Ensure shared code lives in the library crate.
 - [ ] Configure Nx to orchestrate Rust, lint, and security tasks (align with [ADR 0006](adrs/0006-software-components.md) and


### PR DESCRIPTION
- Added three Lambda crates: evefrontier-lambda-route, evefrontier-lambda-scout-gates, evefrontier-lambda-scout-range
- Each crate has minimal handler stub with TODO comments pointing to full implementation
- Added lambda_runtime (0.13) and tokio to workspace dependencies
- Updated workspace members in root Cargo.toml
- All crates compile cleanly, tests pass, clippy clean
- Marked workspace layout TODO as complete in docs/TODO.md
- Full handler implementation deferred to separate tasks (TODO.md lines 110-123)

# Summary

Please provide a short summary of the changes and why they were made.

## Related issues

List any related issues or PRs.

## Changes

- What changed
- Why it changed
- Any notable implementation details

## Verification

Describe how the change was tested (unit tests, manual testing) and how to reproduce.

## Checklist

- [ ] I added tests that prove the change is correct (if applicable)
- [ ] I ran `cargo fmt` and `cargo clippy` and there are no warnings
- [ ] I updated relevant documentation (if applicable)
- [ ] The PR description is clear and contains necessary context
