### PR TITLE
chore: Prepare v0.1.0-alpha.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
   - Dataset downloader with GitHub release caching, atomic writes, and zip extraction
   - Starmap loader with runtime schema detection for multiple dataset formats
   - Graph builders for gate-only, spatial, and hybrid routing modes
-  - Pathfinding algorithms: BFS (unweighted), Dijkstra (weighted), A\* (heuristic-guided)
+  - Pathfinding algorithms: BFS (unweighted), Dijkstra (weighted), `A*` (heuristic-guided)
   - Route constraints: max jump distance, avoided systems, gate-free travel, temperature limits
   - KD-tree spatial index with postcard+zstd serialization and SHA-256 checksums
   - Temperature-aware nearest-neighbor queries with min_external_temp filtering


### PR DESCRIPTION
## Summary

Prepares the CHANGELOG for the first alpha release `v0.1.0-alpha.1`.

## Changes

- Consolidates detailed changelog entries into structured release notes following Keep a Changelog format
- Adds comprehensive feature summary for initial alpha release covering:
  - Core Library (`evefrontier-lib`)
  - CLI (`evefrontier-cli`)
  - AWS Lambda Functions
  - Docker Microservices
  - Observability infrastructure
  - CI/CD workflows
  - Documentation
  - Testing infrastructure
- Documents known issues (kiddo/cmov dependency warning)

## Release Process

After this PR is merged:

1. Create signed tag: `git tag -s v0.1.0-alpha.1 -m "Release v0.1.0-alpha.1"`
2. Push tag: `git push origin v0.1.0-alpha.1`
3. The release workflow will automatically:
   - Build multi-arch binaries (x86_64, aarch64)
   - Generate SHA256 checksums
   - Sign artifacts with cosign (keyless via OIDC)
   - Generate SBOM (CycloneDX format)
   - Create GitHub Release with all artifacts

## Checklist

- [x] CHANGELOG.md updated with release notes
- [x] All tests pass
- [x] Clippy clean
- [x] Security audit passes (yanked dependency warning is documented)