### PR TITLE
fix(ci): Strip v prefix from version to match docker metadata-action output

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -71,6 +71,8 @@ jobs:
           else
             VERSION="${{ github.ref_name }}"
           fi
+          # Strip 'v' prefix to match docker/metadata-action semver output
+          VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building version: ${VERSION}"
       


### PR DESCRIPTION
## Summary

Fixes docker-release workflow failure where `imagetools inspect` was looking for `:v0.1.0-alpha.1` but the image was tagged as `:0.1.0-alpha.1`.

## Problem

The `docker/metadata-action` with `type=semver,pattern={{version}}` strips the `v` prefix automatically (standard semver behavior):
- Input: `v0.1.0-alpha.1` 
- Output tag: `0.1.0-alpha.1`

But the `version` output from the build step was using `github.ref_name` directly, which includes the `v` prefix. This caused a mismatch:

```
# Image was pushed as:
ghcr.io/scetrov/evefrontier-rs/evefrontier-service-route:0.1.0-alpha.1

# But imagetools was looking for:
ghcr.io/scetrov/evefrontier-rs/evefrontier-service-route:v0.1.0-alpha.1
```

## Solution

Strip the `v` prefix from the version output using bash parameter expansion:
```bash
VERSION="${VERSION#v}"
```

This ensures the version output matches what `docker/metadata-action` produces.

## Testing

After merging, re-trigger the docker-release workflow with tag `v0.1.0-alpha.1` to verify the fix.