### PR TITLE
fix(ci): Use correct cargo-sbom output format name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Generate SBOM (CycloneDX format)
         run: |
           VERSION="${{ needs.package.outputs.version }}"
-          cargo sbom --output-format cyclonedx > "evefrontier-${VERSION}.sbom.json"
+          cargo sbom --output-format cyclone_dx_json_1_4 > "evefrontier-${VERSION}.sbom.json"
           echo "SBOM generated:"
           head -50 "evefrontier-${VERSION}.sbom.json"
 


### PR DESCRIPTION
## Summary

Fixes SBOM generation failure in release workflow.

## Problem

The `cargo-sbom` tool uses `cyclone_dx_json_1_4` as the format identifier, not `cyclonedx`:

```
error: invalid value 'cyclonedx' for '--output-format <OUTPUT_FORMAT>'
  [possible values: spdx_json_2_3, cyclone_dx_json_1_4]
```

## Solution

Changed `--output-format cyclonedx` to `--output-format cyclone_dx_json_1_4`.

## Testing

After merging, re-trigger the release workflow with tag `v0.1.0-alpha.1`.