### PR TITLE
Harden supply-chain workflows and governance docs

### DIFF
--- a/.github/workflows/adr-governance.yml
+++ b/.github/workflows/adr-governance.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0  # Full history needed to detect existing ADRs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
 
@@ -33,13 +33,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: "1.97.0"
           components: clippy, rustfmt
 
       - name: Cache cargo directories
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
           path: |
             ~/.cargo/registry
@@ -68,10 +68,10 @@ jobs:
       EVEFRONTIER_SHIP_DATA: ${{ github.workspace }}/docs/fixtures/ship_data.csv
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: "1.97.0"
 
@@ -79,7 +79,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Cache cargo directories
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
           path: |
             ~/.cargo/registry
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -158,13 +158,13 @@ jobs:
 
       - name: Set up Rust
         if: steps.audit-scope.outputs.rust_changed == 'true'
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: "1.97.0"
 
       - name: Cache cargo directories
         if: steps.audit-scope.outputs.rust_changed == 'true'
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
           path: |
             ~/.cargo/registry
@@ -184,7 +184,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.audit-scope.outputs.node_changed == 'true'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
 
@@ -212,15 +212,15 @@ jobs:
     needs: build-and-test # Run after tests pass
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: "1.97.0"
 
       - name: Cache cargo directories
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
           path: |
             ~/.cargo/registry
@@ -254,16 +254,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: "1.97.0"
           components: clippy
 
       - name: Cache cargo directories
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
           path: |
             ~/.cargo/registry
@@ -295,15 +295,15 @@ jobs:
     needs: build-and-test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: "1.97.0"
 
       - name: Cache cargo directories
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: "1.97.0"
 
       - name: Cache cargo directories
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
           path: |
             ~/.cargo/registry
@@ -51,7 +51,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Rust outdated report
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rust-outdated-report
           path: |
@@ -64,10 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
 
@@ -92,7 +92,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Node outdated report
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: node-outdated-report
           path: |

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -65,9 +65,15 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
+            if [[ ! "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+              echo "workflow_dispatch tag must be a v-prefixed semantic version" >&2
+              exit 1
+            fi
+            VERSION="$INPUT_TAG"
           else
             VERSION="${{ github.ref_name }}"
           fi
@@ -188,6 +194,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
           build-args: |
             SERVICE=${{ matrix.service }}
 
@@ -232,7 +239,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         if: always()
         with:
           sarif_file: 'trivy-results-${{ matrix.service }}.sarif'
@@ -277,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: read
 
     strategy:
       matrix:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,34 @@
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "17 14 * * 1"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard supply-chain security
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload Scorecard results
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,83 @@
+# Threat model
+
+## Scope
+
+This document covers the repository's Rust route-planning library, CLI, Lambda functions,
+Kubernetes services, and WASM modules. The system calculates routes and scouting paths from
+EVE Frontier data, including temperature and fuel-aware route information. It does not replace
+the vulnerability-reporting process in [SECURITY.md](../SECURITY.md).
+
+## Assets and security objectives
+
+- Source code, dependency lockfiles, CI/CD workflow definitions, and release configuration must
+  be protected from unauthorized modification.
+- Route and scouting inputs, downloaded data, and generated outputs must retain integrity so that
+  users can make decisions from trustworthy results.
+- Published container images, binaries, SBOMs, scans, and signatures must be traceable to the
+  reviewed build that produced them.
+- Repository and CI credentials, including GitHub tokens and configured secrets, must not be
+  exposed or granted more access than the task requires.
+
+## Trust boundaries and entry points
+
+- CLI arguments, configuration, datasets, and downloaded input files cross from users or external
+  data sources into route calculation and parsing code.
+- Lambda, Kubernetes, and WASM deployment interfaces cross from callers and hosting platforms into
+  service code; deployment-specific authentication, authorization, and network controls are owned
+  by the environment and must be reviewed before deployment.
+- Pull requests, workflow-dispatch inputs, tags, dependencies, and GitHub Actions cross into CI/CD.
+  They are untrusted until validation and review complete.
+- OCI registries and release consumers are external to the repository. Image digests, signatures,
+  SBOMs, and provenance are the integrity evidence at this boundary.
+
+## Primary threats and mitigations
+
+### Untrusted route, scouting, or dataset input
+
+Validate and bound inputs in the relevant parser and service entry point, and add regression tests
+for rejected input. Maintainers must define deployment-specific request limits and monitoring.
+
+### Compromised dependencies or mutable CI actions
+
+Lock dependencies, review dependency changes, pin Actions to reviewed commits, and use Dependabot
+updates. Administrators must enable dependency alerts and require dependency-review checks.
+
+### Unreviewed workflow or release changes
+
+Require PR review, protect workflow and release paths, use least-privilege tokens, and record build
+provenance. Administrators must enforce branch protection, CODEOWNERS, and release permissions.
+
+### Unsafe workflow-dispatch input
+
+Pass dispatch values through step environment variables, quote shell expansion, and accept only
+v-prefixed semantic versions. Maintainers must keep validation aligned with supported release-tag
+formats.
+
+### Forged or substituted OCI images
+
+Publish image provenance, retain SBOMs, scan images, and verify cosign signatures and digests
+before deployment. Release owners must verify registry-attached attestations and restrict
+publishing.
+
+### Secret exposure in source or CI logs
+
+Use GitHub secret expressions rather than hardcoded values and limit token permissions.
+Administrators must enable secret scanning and push protection.
+
+## Security-sensitive decisions
+
+- Docker releases use GitHub OIDC-backed cosign signing and now request Buildx provenance for
+  published images. Consumers should verify signatures, digests, and provenance before deployment.
+- CI workflows use explicit permissions and SHA-pinned third-party actions. Pin updates require
+  review of the upstream commit and its release notes.
+- The accepted DevSecOps practices in
+  [ADR 0007](adrs/0007-devsecops-practices.md) govern CI checks, dependency scanning, and release
+  integrity expectations.
+
+## Assumptions and review cadence
+
+This model deliberately does not assert deployment architecture, authentication, data
+classification, retention, or operational ownership that is not documented in the repository.
+Maintainers should review it when adding an external interface, changing release or credential
+flows, introducing a new data source, or at least annually. Deployment owners should record the
+applicable environment-specific controls alongside their deployment configuration.


### PR DESCRIPTION
## Summary

- Pinned all 29 previously mutable GitHub Action references to reviewed 40-character commit SHAs with release comments.
- Added pull-request dependency review and a scheduled/manual OpenSSF Scorecard workflow with least-privilege job permissions.
- Hardened the Docker release workflow: validates workflow-dispatch tags without shell-context interpolation, enables Buildx provenance for published images, pins CodeQL upload, and narrows the SBOM job to `packages: read`.
- Added a repository threat model covering assets, trust boundaries, primary threats, and explicitly deferred deployment assumptions.

> **No repository settings were changed by this PR automation.** Branch protection, rulesets, secret scanning, and other repository/organization settings require administrator action.

## OpenSSF Scorecard analysis and calls to action

- Prior overall Scorecard evidence is unavailable: the approved validation report contains no previous Scorecard run or score, so no score is inferred here.
- Expected file-based improvements: **Pinned-Dependencies** (all workflow actions are immutable SHA pins), **Dangerous-Workflow** (workflow-dispatch input is not interpolated into shell), and continuous Scorecard reporting via the new workflow.
- The workflow publishes SARIF results on pushes to `main`, its weekly schedule, and manual dispatch. Review the results in **Security → Supply-chain security → Scorecard** after it runs.
- **Branch-Protection**, **Code-Review**, **Signed-Releases**, and **Vulnerabilities** remain administrator or maintainer follow-up items.

## Validation

- [x] `git diff --check`
- [x] Workflow YAML parsed successfully; all workflow `uses:` references use 40-character SHAs.
- [x] All changed/new action pins were matched to their upstream release tags with `git ls-remote`.
- [x] `cargo +1.97.0 test --workspace` passed.
- [x] `cargo +1.97.0 fmt --all -- --check` passed.
- [x] `docs/threat-model.md` passed focused Markdown linting.
- [x] New workflow YAML files passed Prettier checking.
- [x] Token/secret pattern scans of the diff and this PR body passed.
- [x] `actionlint` was not run because it is not installed in this environment.
- [x] Repository-wide `pnpm lint:md` and `pnpm format:check` remain failing on pre-existing files outside this change (including `specs/` Markdown and Helm-template/JSON parsing); focused checks for changed new files passed.

## Manual follow-up required

The PR only changes repository files. A repository, organization, or enterprise administrator still needs to complete these settings tasks:

- [x] Merge this PR after review and passing checks.
- [x] In **Settings → Rules → Rulesets** (or **Settings → Branches → Branch protection rules**), protect `main`: require pull requests, at least one approval, stale-approval dismissal where appropriate, required status checks, restricted direct pushes, and restrictions on force pushes, branch creation, and deletion. Require signed commits or tags if compatible with the team workflow.
- [x] Add required status checks only after workflows have run. Copy the exact names from the PR Checks tab; at minimum review `Build and test workspace`, `Dependency review`, CodeQL jobs, and `Scorecard supply-chain security` if the team wants Scorecard blocking. Confirm a test PR cannot merge while a required check fails.
- [x] Do not enable CODEOWNERS enforcement until maintainers provide valid GitHub users or teams and a reviewed path-to-owner mapping. Then add CODEOWNERS, protect `.github/workflows/`, dependency manifests/lockfiles, release files, and security documentation, and verify a test PR requests the expected owner review.
- [x] In **Settings → Code security and analysis**, enable or verify secret scanning, push protection, validity checks where available, dependency graph, Dependabot alerts, Dependabot security updates, malware detection, and routed code-scanning alert ownership. Confirm their inheritance if managed by organization policy.
- [x] Verify existing `.github/dependabot.yml` covers Cargo, npm, and GitHub Actions, and update its grouping, pull-request limit, and cooldown policy in a reviewed follow-up if the current configuration does not meet the repository policy.
- [x] Verify a published OCI image has attached Buildx provenance, an SBOM, and a valid cosign signature before deployment. Restrict tag/release publishing to trusted maintainers or environments and enable immutable releases in **Settings → General → Releases** where available. Retain verification output or links to release provenance/SBOM/signature evidence.
- [x] Document AI-agent credential scope, revocation, human review requirements, dependency-review requirements, and the prohibition on privileged execution of untrusted code. Confirm agents cannot push directly to protected branches.

Suggested verification evidence: an exported ruleset or screenshot, the exact required check names, confirmation of security-analysis settings, a CODEOWNERS recognition/test-PR result after owners are supplied, and release provenance/SBOM/signature verification output.

No repository settings were changed by this PR automation.

## References

- Approved proposal: `/home/scetrov/.agents/skills/github-supply-chain-hardening-analysis/proposals/Scetrov_evefrontier-rs.json`
- Current-state validation: `/home/scetrov/source/security-hardening/remediation-validation/evefrontier-rs.md`
